### PR TITLE
minor change to facilitate https://github.com/enketo/enketo-validate/issues/2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var xslModel, xslForm,
 	fs = require('fs'),
 	path = require('path'),
-	xslModelPath = path.resolve(__dirname, './xsl/openrosa2xmlmodel.xsl'),
-	xslFormPath = path.resolve(__dirname, './xsl/openrosa2html5form.xsl');
+	xslModelPath = path.join(__dirname, './xsl/openrosa2xmlmodel.xsl'),
+	xslFormPath = path.join(__dirname, './xsl/openrosa2html5form.xsl');
 
 // only read once
 xslModel = fs.readFileSync(xslModelPath, {encoding: 'utf8'});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "enketo-xslt",
-    "version": "1.15.2",
+    "version": "1.15.4",
     "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     ],
     "author": "Martijn van de Rijdt",
     "license": "Apache-2.0",
-    "dependencies": {
-        "mocha": "^4.1.0",
-        "test": "^0.6.0"
+    "devDependencies": {
+        "mocha": "^4.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
         "Transformer"
     ],
     "author": "Martijn van de Rijdt",
-    "license": "Apache-2.0"
+    "license": "Apache-2.0",
+    "dependencies": {
+        "mocha": "^4.1.0",
+        "test": "^0.6.0"
+    }
 }


### PR DESCRIPTION
Please see https://github.com/enketo/enketo-validate/issues/2#issuecomment-355014977

For some reason, `pkg` can't resolve the location of these `xsl` files unless the `join` function is used instead of `resolve`. It seems to work the same - the tests pass.